### PR TITLE
add 'gesture' command for CCConsole

### DIFF
--- a/build/cocos2d_libs.xcodeproj/project.pbxproj
+++ b/build/cocos2d_libs.xcodeproj/project.pbxproj
@@ -3763,6 +3763,12 @@
 		A0E749F81BA8FD7F001A8332 /* UIEditBoxImpl-common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A0E749F51BA8FD7F001A8332 /* UIEditBoxImpl-common.cpp */; };
 		A0E749F91BA8FD7F001A8332 /* UIEditBoxImpl-common.h in Headers */ = {isa = PBXBuildFile; fileRef = A0E749F61BA8FD7F001A8332 /* UIEditBoxImpl-common.h */; };
 		A0E749FA1BA8FD7F001A8332 /* UIEditBoxImpl-common.h in Headers */ = {isa = PBXBuildFile; fileRef = A0E749F61BA8FD7F001A8332 /* UIEditBoxImpl-common.h */; };
+		A55B89BF1C6851DF009B2B6F /* CCConsoleGestureCmd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A55B89BD1C6851DF009B2B6F /* CCConsoleGestureCmd.cpp */; };
+		A55B89C01C6851DF009B2B6F /* CCConsoleGestureCmd.h in Headers */ = {isa = PBXBuildFile; fileRef = A55B89BE1C6851DF009B2B6F /* CCConsoleGestureCmd.h */; };
+		A55B89C11C685207009B2B6F /* CCConsoleGestureCmd.h in Headers */ = {isa = PBXBuildFile; fileRef = A55B89BE1C6851DF009B2B6F /* CCConsoleGestureCmd.h */; };
+		A55B89C21C685210009B2B6F /* CCConsoleGestureCmd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A55B89BD1C6851DF009B2B6F /* CCConsoleGestureCmd.cpp */; };
+		A55B89C31C685212009B2B6F /* CCConsoleGestureCmd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A55B89BD1C6851DF009B2B6F /* CCConsoleGestureCmd.cpp */; };
+		A55B89C41C685212009B2B6F /* CCConsoleGestureCmd.h in Headers */ = {isa = PBXBuildFile; fileRef = A55B89BE1C6851DF009B2B6F /* CCConsoleGestureCmd.h */; };
 		B2165EEA19921124000BE3E6 /* CCPrimitiveCommand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B257B45E198A353E00D9A687 /* CCPrimitiveCommand.cpp */; };
 		B217703C1977ECB4009EE11B /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B217703B1977ECB4009EE11B /* IOKit.framework */; };
 		B21770401977ECE6009EE11B /* OpenGL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B217703F1977ECE6009EE11B /* OpenGL.framework */; };
@@ -6574,6 +6580,8 @@
 		A07A4D641783777C0073F6A7 /* libcocos2d iOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libcocos2d iOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A0E749F51BA8FD7F001A8332 /* UIEditBoxImpl-common.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "UIEditBoxImpl-common.cpp"; sourceTree = "<group>"; };
 		A0E749F61BA8FD7F001A8332 /* UIEditBoxImpl-common.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIEditBoxImpl-common.h"; sourceTree = "<group>"; };
+		A55B89BD1C6851DF009B2B6F /* CCConsoleGestureCmd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = CCConsoleGestureCmd.cpp; path = ../base/CCConsoleGestureCmd.cpp; sourceTree = "<group>"; };
+		A55B89BE1C6851DF009B2B6F /* CCConsoleGestureCmd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CCConsoleGestureCmd.h; path = ../base/CCConsoleGestureCmd.h; sourceTree = "<group>"; };
 		B20564AA1A6E5744001C1B6E /* ccShader_PositionColorTextureAsPointsize.vert */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.glsl; path = ccShader_PositionColorTextureAsPointsize.vert; sourceTree = "<group>"; };
 		B217703B1977ECB4009EE11B /* IOKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = IOKit.framework; path = System/Library/Frameworks/IOKit.framework; sourceTree = SDKROOT; };
 		B217703D1977ECC1009EE11B /* AudioToolbox.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
@@ -7838,6 +7846,8 @@
 				50ABBDCB1925AB6E00A911A9 /* CCConfiguration.h */,
 				50ABBDCC1925AB6E00A911A9 /* CCConsole.cpp */,
 				50ABBDCD1925AB6E00A911A9 /* CCConsole.h */,
+				A55B89BD1C6851DF009B2B6F /* CCConsoleGestureCmd.cpp */,
+				A55B89BE1C6851DF009B2B6F /* CCConsoleGestureCmd.h */,
 				50ABBDCE1925AB6E00A911A9 /* CCData.cpp */,
 				50ABBDCF1925AB6E00A911A9 /* CCData.h */,
 				50ABBDD01925AB6E00A911A9 /* CCDataVisitor.cpp */,
@@ -11591,6 +11601,7 @@
 				B665E24C1AA80A6500DDB1C5 /* CCPUColorAffector.h in Headers */,
 				29394CF019B01DBA00D2DE1A /* UIWebView.h in Headers */,
 				15AE186519AAD31D00C27E9E /* CDOpenALSupport.h in Headers */,
+				A55B89C01C6851DF009B2B6F /* CCConsoleGestureCmd.h in Headers */,
 				B6CAAFE81AF9A9E100B9B856 /* CCPhysics3DComponent.h in Headers */,
 				15AE1B5C19AADA9900C27E9E /* UITextAtlas.h in Headers */,
 				1A5702FC180BCE750088DEC7 /* CCTMXXMLParser.h in Headers */,
@@ -12118,6 +12129,7 @@
 				507B3DBB1C31BDD30067B53E /* btDantzigLCP.h in Headers */,
 				507B3DBC1C31BDD30067B53E /* CCPUAlignAffectorTranslator.h in Headers */,
 				507B3DBD1C31BDD30067B53E /* CCActionEase.h in Headers */,
+				A55B89C41C685212009B2B6F /* CCConsoleGestureCmd.h in Headers */,
 				507B3DBE1C31BDD30067B53E /* CCActionGrid.h in Headers */,
 				507B3DBF1C31BDD30067B53E /* CCComController.h in Headers */,
 				507B3DC01C31BDD30067B53E /* NodeReaderProtocol.h in Headers */,
@@ -13126,6 +13138,7 @@
 				B6CAB41C1AF9AA1A00B9B856 /* btDantzigLCP.h in Headers */,
 				B665E2051AA80A6500DDB1C5 /* CCPUAlignAffectorTranslator.h in Headers */,
 				1A570070180BC5A10088DEC7 /* CCActionEase.h in Headers */,
+				A55B89C11C685207009B2B6F /* CCConsoleGestureCmd.h in Headers */,
 				1A570074180BC5A10088DEC7 /* CCActionGrid.h in Headers */,
 				15AE194A19AAD35100C27E9E /* CCComController.h in Headers */,
 				382384161A259092002C4610 /* NodeReaderProtocol.h in Headers */,
@@ -14843,6 +14856,7 @@
 				B6CAAFFE1AF9A9E100B9B856 /* CCPhysicsSprite3D.cpp in Sources */,
 				B6CAB1ED1AF9AA1A00B9B856 /* btBroadphaseProxy.cpp in Sources */,
 				B29594B41926D5EC003EEF37 /* CCMeshCommand.cpp in Sources */,
+				A55B89BF1C6851DF009B2B6F /* CCConsoleGestureCmd.cpp in Sources */,
 				15AE189619AAD33D00C27E9E /* CCMenuItemImageLoader.cpp in Sources */,
 				B665E23E1AA80A6500DDB1C5 /* CCPUCircleEmitterTranslator.cpp in Sources */,
 				15AE1BB719AADFEF00C27E9E /* WebSocket.cpp in Sources */,
@@ -15636,6 +15650,7 @@
 				507B3CB01C31BDD30067B53E /* Node3DReader.cpp in Sources */,
 				507B3CB11C31BDD30067B53E /* CCAsyncTaskPool.cpp in Sources */,
 				507B3CB21C31BDD30067B53E /* CCConsole.cpp in Sources */,
+				A55B89C31C685212009B2B6F /* CCConsoleGestureCmd.cpp in Sources */,
 				507B3CB31C31BDD30067B53E /* Bone.c in Sources */,
 				507B3CB41C31BDD30067B53E /* Win32ThreadSupport.cpp in Sources */,
 				507B3CB51C31BDD30067B53E /* CCPUVortexAffector.cpp in Sources */,
@@ -16481,6 +16496,7 @@
 				182C5CB41A95964C00C30D34 /* Node3DReader.cpp in Sources */,
 				B63990CD1A490AFE00B07923 /* CCAsyncTaskPool.cpp in Sources */,
 				50ABBE361925AB6F00A911A9 /* CCConsole.cpp in Sources */,
+				A55B89C21C685210009B2B6F /* CCConsoleGestureCmd.cpp in Sources */,
 				B29A7E1419EE1B7700872B35 /* Bone.c in Sources */,
 				B6CAB4F01AF9AA1A00B9B856 /* Win32ThreadSupport.cpp in Sources */,
 				B665E4371AA80A6600DDB1C5 /* CCPUVortexAffector.cpp in Sources */,

--- a/cocos/2d/CMakeLists.txt
+++ b/cocos/2d/CMakeLists.txt
@@ -71,6 +71,7 @@ set(COCOS_2D_SRC
   ../external/clipper/clipper.cpp
   2d/CCTextFieldTTF.cpp
   2d/CCTileMapAtlas.cpp
+  2d/CCTouchAction.cpp
   2d/CCTMXLayer.cpp
   2d/CCTMXObjectGroup.cpp
   2d/CCTMXTiledMap.cpp

--- a/cocos/2d/libcocos2d.vcxproj
+++ b/cocos/2d/libcocos2d.vcxproj
@@ -412,6 +412,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\chipmunk\prebuilt\win32\release-lib\*.*
     <ClCompile Include="..\base\ccCArray.cpp" />
     <ClCompile Include="..\base\CCConfiguration.cpp" />
     <ClCompile Include="..\base\CCConsole.cpp" />
+    <ClCompile Include="..\base\CCConsoleGestureCmd.cpp" />
     <ClCompile Include="..\base\CCData.cpp" />
     <ClCompile Include="..\base\CCDataVisitor.cpp" />
     <ClCompile Include="..\base\CCDirector.cpp" />
@@ -992,6 +993,7 @@ xcopy /Y /Q "$(ProjectDir)..\..\external\chipmunk\prebuilt\win32\release-lib\*.*
     <ClInclude Include="..\base\ccConfig.h" />
     <ClInclude Include="..\base\CCConfiguration.h" />
     <ClInclude Include="..\base\CCConsole.h" />
+    <ClInclude Include="..\base\CCConsoleGestureCmd.h" />
     <ClInclude Include="..\base\CCData.h" />
     <ClInclude Include="..\base\CCDataVisitor.h" />
     <ClInclude Include="..\base\CCDirector.h" />

--- a/cocos/2d/libcocos2d.vcxproj.filters
+++ b/cocos/2d/libcocos2d.vcxproj.filters
@@ -1944,6 +1944,9 @@
     <ClCompile Include="CCTouchAction.cpp">
       <Filter>2d</Filter>
     </ClCompile>
+    <ClCompile Include="..\base\CCConsoleGestureCmd.cpp">
+      <Filter>base</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\physics\CCPhysicsBody.h">
@@ -3793,6 +3796,9 @@
     </ClInclude>
     <ClInclude Include="CCTouchAction.h">
       <Filter>2d</Filter>
+    </ClInclude>
+    <ClInclude Include="..\base\CCConsoleGestureCmd.h">
+      <Filter>base</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -113,6 +113,7 @@ base/CCAsyncTaskPool.cpp \
 base/CCAutoreleasePool.cpp \
 base/CCConfiguration.cpp \
 base/CCConsole.cpp \
+base/CCConsoleGestureCmd.cpp \
 base/CCController-android.cpp \
 base/CCController.cpp \
 base/CCData.cpp \

--- a/cocos/base/CCConsoleGestureCmd.cpp
+++ b/cocos/base/CCConsoleGestureCmd.cpp
@@ -1,0 +1,603 @@
+/****************************************************************************
+ Copyright (c) 2016      Naruto TAKAHASHI <tnaruto@gmail.com>
+ http://www.cocos2d-x.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+#include "CCConsoleGestureCmd.h"
+#include <sstream>
+
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#include <io.h>
+#include <WS2tcpip.h>
+#include <Winsock2.h>
+#if defined(__MINGW32__)
+#include "platform/win32/inet_pton_mingw.h"
+#endif
+#define bzero(a, b) memset(a, 0, b);
+#if (CC_TARGET_PLATFORM == CC_PLATFORM_WINRT)
+#include "platform/winrt/inet_ntop_winrt.h"
+#include "platform/winrt/inet_pton_winrt.h"
+#include "platform/winrt/CCWinRTUtils.h"
+#endif
+#else
+#include <netdb.h>
+#include <unistd.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <sys/ioctl.h>
+#endif
+
+#include "base/CCDirector.h"
+#include "base/CCScheduler.h"
+#include "base/CCConfiguration.h"
+#include "platform/CCFileUtils.h"
+#include "renderer/CCTextureCache.h"
+#include "base/base64.h"
+#include "base/ccUtils.h"
+#include "base/allocator/CCAllocatorDiagnostics.h"
+#include "2d/CCTouchAction.h"
+#include "base/CCEventListenerTouch.h"
+#include "base/CCEventDispatcher.h"
+
+USING_NS_CC;
+
+ConsoleGestureCmd::ConsoleGestureCmd()
+        : touchPriority(DEFAULT_TOUCH_PRIORITY)
+{
+    command.name = "gesture";
+    command.help = "simulate gesture event via console, type [gesture help] to list supported directives";
+    command.callback = CC_CALLBACK_2(ConsoleGestureCmd::commandGesture, this);
+
+    addSubCommand("help", "", CC_CALLBACK_2(ConsoleGestureCmd::commandHelp, this));
+    // sync gesture commands
+    addSubCommand("tap", "x y [duration] [force tap]: simulate tap at (x,y)", CC_CALLBACK_2(ConsoleGestureCmd::commandTap, this));
+    addSubCommand("swipe", "srcX srcY dstX dstY [duration]: simulate swipe from (srcX,srcY) to (dstX,dstY)", CC_CALLBACK_2(ConsoleGestureCmd::commandSwipe, this));
+    addSubCommand("pinchIn", "centerX centerY initDistance pinchDistance [degree] [duration]: simulate pinchIn", CC_CALLBACK_2(ConsoleGestureCmd::commandPinchIn, this));
+    addSubCommand("pinchOut", "centerX centerY initDistance pinchDistance [degree] [duration]: simulate pinchOut", CC_CALLBACK_2(ConsoleGestureCmd::commandPinchOut, this));
+
+    // async gesture commands
+    addSubCommand("tapAsync", "x y [duration] [force tap] [asyncID]: simulate async tap at (x,y)", CC_CALLBACK_2(ConsoleGestureCmd::commandTapAsync, this));
+    addSubCommand("swipeAsync", "srcX srcY dstX dstY [duration] [asyncID]: simulate async swipe from (srcX,srcY) to (dstX,dstY)", CC_CALLBACK_2(ConsoleGestureCmd::commandSwipeAsync, this));
+    addSubCommand("pinchInAsync", "centerX centerY initDistance pinchDistance [degree] [duration] [asyncID]: simulate async pinchIn", CC_CALLBACK_2(ConsoleGestureCmd::commandPinchInAsync, this));
+    addSubCommand("pinchOutAsync", "centerX centerY initDistance pinchDistance [degree] [duration] [asyncID]: simulate async pinchOut", CC_CALLBACK_2(ConsoleGestureCmd::commandPinchOutAsync, this));
+
+    // sync primitive touch commands
+    addSubCommand("touchBegin", "x y touchID: simulate touchBegan (x,y) with touchID", CC_CALLBACK_2(ConsoleGestureCmd::commandTouchBegin, this));
+    addSubCommand("touchMove", "x y touchID: simulate touchMoved (x,y) with touchID", CC_CALLBACK_2(ConsoleGestureCmd::commandTouchMove, this));
+    addSubCommand("touchEnd", "x y touchID: simulate touchEnded (x,y) with touchID", CC_CALLBACK_2(ConsoleGestureCmd::commandTouchEnd, this));
+    addSubCommand("touchCancel", "x y touchID: simulate touchCanceled (x,y) with touchID", CC_CALLBACK_2(ConsoleGestureCmd::commandTouchCancel, this));
+    addSubCommand("touchStatus", ": display simulate touchIDs List", CC_CALLBACK_2(ConsoleGestureCmd::commandTouchStatus, this));
+}
+
+ConsoleGestureCmd::~ConsoleGestureCmd()
+{
+    for (auto &itr : touchesMap) {
+        Touch *touch = itr.second;
+        touch->release();
+    }
+    touchesMap.clear();
+}
+
+void ConsoleGestureCmd::addSubCommand(const std::string &name, const std::string &help, std::function<void(int, const std::string &)> callback)
+{
+    subCommands.emplace_back(Console::Command{name, help, callback});
+}
+
+void ConsoleGestureCmd::commandGesture(int fd, const std::string &args)
+{
+    int ret;
+    auto argv = split(args,' ');
+    auto helpCommand = std::find_if(subCommands.begin(), subCommands.end(), [argv](const struct Console::Command &command) {
+        return (command.name == "help")? true : false;
+    });
+
+    if(argv.empty()) {
+        helpCommand->callback(fd, args);
+    } else {
+        auto command = std::find_if(subCommands.begin(), subCommands.end(), [argv](const struct Console::Command &command) {
+            return (argv[0] == command.name)? true : false;
+        });
+        if(command == subCommands.end()) {
+            helpCommand->callback(fd, args);
+            return;
+        }
+        command->callback(fd, args);
+    }
+}
+
+// import from CCConsole
+std::vector<std::string> &ConsoleGestureCmd::split(const std::string &s, char delim, std::vector<std::string> &elems)
+{
+    std::stringstream ss(s);
+    std::string item;
+    while (std::getline(ss, item, delim)) {
+        elems.push_back(item);
+    }
+    return elems;
+}
+
+// import from CCConsole
+std::vector<std::string> ConsoleGestureCmd::split(const std::string &s, char delim)
+{
+    std::vector<std::string> elems;
+    split(s, delim, elems);
+    return elems;
+}
+
+void ConsoleGestureCmd::commandHelp(int fd, const std::string &args)
+{
+    int ret;
+    std::string logStr;
+    logStr.append(command.name);
+    logStr.append(" commands:\n");
+    for(auto &cmd : this->subCommands) {
+        if(cmd.name == "help") continue;
+        std::stringstream ss;
+        ss << "\t" << cmd.name << " " << cmd.help << std::endl;
+        logStr.append(ss.str());
+    }
+    ret = send(fd, logStr.c_str(), logStr.size(), 0);
+    if(ret < 0) {
+        CCLOG("send() error");
+    }
+}
+
+void ConsoleGestureCmd::commandTapInternal(int fd, const std::string &args, bool async)
+{
+    std::mutex m;
+    std::condition_variable waitCocosThread;
+    std::unique_lock<std::mutex> lock(m);
+
+    auto argv = split(args, ' ');
+    if(argv.size() < 3) return;
+
+    int touchPriority = this->touchPriority;
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([fd, argv, async, &waitCocosThread, touchPriority]() {
+        std::string xStr = argv[1];
+        std::string yStr = argv[2];
+        std::string durationStr = (argv.size() >= 4)? argv[3] : "";
+        std::string forceStr = (argv.size() >= 5)? argv[4] : ""; // TODO: implement
+        std::string asyncIDStr = (argv.size() >= 6)? argv[5] : "";
+
+        Vec2 pos(std::stof(xStr), std::stof(yStr));
+        float duration = (durationStr != "")? std::stof(durationStr) : 1.0f;
+        auto tap = Tap::create(duration, pos, true);
+        
+        auto director = Director::getInstance();
+        auto runningScene = director->getRunningScene();
+        auto listener = EventListenerTouchOneByOne::create();
+        listener->onTouchBegan = [](Touch *touch, Event *event) { return true; };
+        listener->onTouchEnded = [fd, async, &waitCocosThread, asyncIDStr, listener](Touch *touch, Event *event) {
+            Director::getInstance()->getEventDispatcher()->removeEventListener(listener);
+            if(async) {
+                if(!asyncIDStr.empty()) {
+                    std::string logStr;
+                    logStr.append(">> ");
+                    logStr.append(asyncIDStr);
+                    logStr.append("\n");
+                    int ret = send(fd, logStr.c_str(), logStr.size(), 0);
+                    if(ret < 0) {
+                        CCLOG("send() error");
+                    }
+                }
+            } else {
+                waitCocosThread.notify_one();
+            }};
+        director->getEventDispatcher()->addEventListenerWithFixedPriority(listener, touchPriority);
+        runningScene->runAction(tap);
+    });
+    if(!async) {
+        waitCocosThread.wait(lock);
+    }
+}
+
+void ConsoleGestureCmd::commandSwipeInternal(int fd, const std::string &args, bool async)
+{
+    std::mutex m;
+    std::condition_variable waitCocosThread;
+    std::unique_lock<std::mutex> lock(m);
+
+    auto argv = split(args, ' ');
+    if(argv.size() < 5) return;
+
+    int touchPriority = this->touchPriority;
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([fd, argv, async, &waitCocosThread, touchPriority]() {
+        std::string srcXStr = argv[1];
+        std::string srcYStr = argv[2];
+        std::string dstXStr = argv[3];
+        std::string dstYStr = argv[4];
+        std::string durationStr = (argv.size() >= 6)? argv[5] : "";
+        std::string asyncIDStr = (argv.size() >= 7)? argv[6] : "";
+
+        Vec2 srcPos(std::stof(srcXStr), std::stof(srcYStr));
+        Vec2 dstPos(std::stof(dstXStr), std::stof(dstYStr));
+        float duration = (durationStr != "")? std::stof(durationStr) : 1.0f ;
+        auto swipe = SwipeBetween::create(duration, srcPos, dstPos);
+
+        auto director = Director::getInstance();
+        auto runningScene = director->getRunningScene();
+        auto listener = EventListenerTouchOneByOne::create();
+        listener->onTouchBegan = [](Touch *touch, Event *event) { return true; };
+        listener->onTouchEnded = [fd, async, &waitCocosThread, asyncIDStr, listener](Touch *touch, Event *event) {
+            Director::getInstance()->getEventDispatcher()->removeEventListener(listener);
+            if(async) {
+                if(!asyncIDStr.empty()) {
+                    std::string logStr;
+                    logStr.append(">> ");
+                    logStr.append(asyncIDStr);
+                    logStr.append("\n");
+                    int ret = send(fd, logStr.c_str(), logStr.size(), 0);
+                    if(ret < 0) {
+                        CCLOG("send() error");
+                    }
+                }
+            } else {
+                waitCocosThread.notify_one();
+            }};
+        director->getEventDispatcher()->addEventListenerWithFixedPriority(listener, touchPriority);
+        runningScene->runAction(swipe);
+    });
+    if(!async) {
+        waitCocosThread.wait(lock);
+    }
+}
+
+void ConsoleGestureCmd::commandPinchInInternal(int fd, const std::string &args, bool async)
+{
+    std::mutex m;
+    std::condition_variable waitCocosThread;
+    std::unique_lock<std::mutex> lock(m);
+
+    auto argv = split(args, ' ');
+    if(argv.size() < 5) return;
+
+    int touchPriority = this->touchPriority;
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([fd, argv, async, &waitCocosThread, touchPriority]() {
+        std::string centerXStr = argv[1];
+        std::string centerYStr = argv[2];
+        std::string initDistanceStr = argv[3];
+        std::string pinchDistanceStr = argv[4];
+        std::string degreeStr = (argv.size() >= 6)? argv[5] : "";
+        std::string durationStr = (argv.size() >= 7)? argv[6] : "";
+        std::string asyncIDStr = (argv.size() >= 8)? argv[7] : "";
+
+        Vec2 centerPos(std::stof(centerXStr), std::stof(centerYStr));
+        float initDistance = std::stof(initDistanceStr);
+        float pinchDistance = std::stof(pinchDistanceStr);
+        float degree = std::stof(degreeStr);
+        float duration = (durationStr != "")? std::stof(durationStr) : 1.0f ;
+        auto pinchIn = PinchIn::create(duration, centerPos, initDistance, pinchDistance, true, degree);
+
+        auto director = Director::getInstance();
+        auto runningScene = director->getRunningScene();
+        auto listener = EventListenerTouchOneByOne::create();
+        listener->onTouchBegan = [](Touch *touch, Event *event) { return true; };
+        listener->onTouchEnded = [fd, async, &waitCocosThread, asyncIDStr, listener](Touch *touch, Event *event) {
+            Director::getInstance()->getEventDispatcher()->removeEventListener(listener);
+            if(async) {
+                if(!asyncIDStr.empty()) {
+                    std::string logStr;
+                    logStr.append(">> ");
+                    logStr.append(asyncIDStr);
+                    logStr.append("\n");
+                    int ret = send(fd, logStr.c_str(), logStr.size(), 0);
+                    if(ret < 0) {
+                        CCLOG("send() error");
+                    }
+                }
+            } else {
+                waitCocosThread.notify_one();
+            }};
+        director->getEventDispatcher()->addEventListenerWithFixedPriority(listener, touchPriority);
+        runningScene->runAction(pinchIn);
+    });
+    if(!async) {
+        waitCocosThread.wait(lock);
+    }
+}
+
+void ConsoleGestureCmd::commandPinchOutInternal(int fd, const std::string &args, bool async)
+{
+    std::mutex m;
+    std::condition_variable waitCocosThread;
+    std::unique_lock<std::mutex> lock(m);
+
+    auto argv = split(args, ' ');
+    if(argv.size() < 5) return;
+
+    int touchPriority = this->touchPriority;
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([fd, argv, async, &waitCocosThread, touchPriority]() {
+        std::string centerXStr = argv[1];
+        std::string centerYStr = argv[2];
+        std::string initDistanceStr = argv[3];
+        std::string pinchDistanceStr = argv[4];
+        std::string degreeStr = (argv.size() >= 6)? argv[5] : "";
+        std::string durationStr = (argv.size() >= 7)? argv[6] : "";
+        std::string asyncIDStr = (argv.size() >= 8)? argv[7] : "";
+
+        Vec2 centerPos(std::stof(centerXStr), std::stof(centerYStr));
+        float initDistance = std::stof(initDistanceStr);
+        float pinchDistance = std::stof(pinchDistanceStr);
+        float degree = std::stof(degreeStr);
+        float duration = (durationStr != "")? std::stof(durationStr) : 1.0f ;
+        auto pinchOut = PinchOut::create(duration, centerPos, initDistance, pinchDistance, true, degree);
+
+        auto director = Director::getInstance();
+        auto runningScene = director->getRunningScene();
+        auto listener = EventListenerTouchOneByOne::create();
+        listener->onTouchBegan = [](Touch *touch, Event *event) { return true; };
+        listener->onTouchEnded = [fd, async, &waitCocosThread, asyncIDStr, listener](Touch *touch, Event *event) {
+            Director::getInstance()->getEventDispatcher()->removeEventListener(listener);
+            if(async) {
+                if(!asyncIDStr.empty()) {
+                    std::string logStr;
+                    logStr.append(">> ");
+                    logStr.append(asyncIDStr);
+                    logStr.append("\n");
+                    int ret = send(fd, logStr.c_str(), logStr.size(), 0);
+                    if(ret < 0) {
+                        CCLOG("send() error");
+                    }
+                }
+            } else {
+                waitCocosThread.notify_one();
+            }};
+        director->getEventDispatcher()->addEventListenerWithFixedPriority(listener, touchPriority);
+        runningScene->runAction(pinchOut);
+    });
+    if(!async) {
+        waitCocosThread.wait(lock);
+    }
+}
+
+void ConsoleGestureCmd::commandTouchBegin(int fd, const std::string &args)
+{
+    std::mutex m;
+    std::condition_variable waitCocosThread;
+    std::unique_lock<std::mutex> lock(m);
+
+    auto argv = split(args, ' ');
+    // args: touchBegin x y touchID
+    if(argv.size() < 4) return;
+
+    std::string xStr = argv[1];
+    std::string yStr = argv[2];
+    std::string touchIDStr = argv[3];
+    float x = std::stof(xStr);
+    float y = std::stof(yStr);
+    int touchID = std::stoi(touchIDStr);
+
+    if(findTouch(touchID) != nullptr) {
+        int ret;
+        std::string logStr;
+        logStr.append("already registered touchID: ");
+        logStr.append(touchIDStr);
+        logStr.append("\n");
+        ret = send(fd, logStr.c_str(), logStr.size(), 0);
+        if(ret < 0) {
+            CCLOG("send() error");
+        }
+        return;
+    }
+    addTouch(x, y, touchID);
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([fd, argv, &waitCocosThread, touchID, this]() {
+        auto director = Director::getInstance();
+        auto runningScene = director->getRunningScene();
+        Touch *touch = this->findTouch(touchID);
+        Vec2 pos = touch->getLocationInView();
+        auto touchBegan = TouchBegan::create(touch, pos, true);
+        runningScene->runAction(touchBegan);
+        waitCocosThread.notify_one();
+    });
+    waitCocosThread.wait(lock);
+}
+
+void ConsoleGestureCmd::commandTouchMove(int fd, const std::string &args)
+{
+    std::mutex m;
+    std::condition_variable waitCocosThread;
+    std::unique_lock<std::mutex> lock(m);
+
+    auto argv = split(args, ' ');
+    // args: touchMove x y touchID
+    if(argv.size() < 4) return;
+
+    std::string xStr = argv[1];
+    std::string yStr = argv[2];
+    std::string touchIDStr = argv[3];
+    float x = std::stof(xStr);
+    float y = std::stof(yStr);
+    int touchID = std::stoi(touchIDStr);
+
+    Touch *touch = findTouch(touchID);
+    if(!touch) return;
+    touch->setTouchInfo(touchID, x, y);
+
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([fd, argv, &waitCocosThread, touch, this]() {
+        auto director = Director::getInstance();
+        auto runningScene = director->getRunningScene();
+        Vec2 pos = touch->getLocationInView();
+        auto touchMoved = TouchMoved::create(touch, pos);
+
+        runningScene->runAction(touchMoved);
+        waitCocosThread.notify_one();
+    });
+    waitCocosThread.wait(lock);
+}
+
+void ConsoleGestureCmd::commandTouchEnd(int fd, const std::string &args)
+{
+    std::mutex m;
+    std::condition_variable waitCocosThread;
+    std::unique_lock<std::mutex> lock(m);
+
+    auto argv = split(args, ' ');
+    // args: touchEnd x y touchID
+    if(argv.size() < 4) return;
+
+    std::string xStr = argv[1];
+    std::string yStr = argv[2];
+    std::string touchIDStr = argv[3];
+    float x = std::stof(xStr);
+    float y = std::stof(yStr);
+    int touchID = std::stoi(touchIDStr);
+
+    Touch *touch = findTouch(touchID);
+    if(!touch) return;
+    touch->setTouchInfo(touchID, x, y);
+    removeTouch(touchID);
+
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([fd, argv, &waitCocosThread, touch]() {
+        auto director = Director::getInstance();
+        auto runningScene = director->getRunningScene();
+        Vec2 pos = touch->getLocationInView();
+        auto touchEnded = TouchEnded::create(touch, pos);
+        runningScene->runAction(touchEnded);
+        waitCocosThread.notify_one();
+    });
+    waitCocosThread.wait(lock);
+}
+
+void ConsoleGestureCmd::commandTouchCancel(int fd, const std::string &args)
+{
+    std::mutex m;
+    std::condition_variable waitCocosThread;
+    std::unique_lock<std::mutex> lock(m);
+
+    auto argv = split(args, ' ');
+    // args: touchEnded x y touchID
+    if(argv.size() < 3) return;
+
+    std::string xStr = argv[1];
+    std::string yStr = argv[2];
+    std::string touchIDStr = argv[3];
+    float x = std::stof(xStr);
+    float y = std::stof(yStr);
+    int touchID = std::stoi(touchIDStr);
+
+    Touch *touch = findTouch(touchID);
+    if(!touch) return;
+    touch->setTouchInfo(touchID, x, y);
+    removeTouch(touchID);
+
+    Director::getInstance()->getScheduler()->performFunctionInCocosThread([fd, argv, &waitCocosThread, touch]() {
+        auto director = Director::getInstance();
+        auto runningScene = director->getRunningScene();
+        Vec2 pos = touch->getLocationInView();
+        auto touchEnded = TouchCancelled::create(touch, pos);
+        runningScene->runAction(touchEnded);
+        waitCocosThread.notify_one();
+    });
+    waitCocosThread.wait(lock);
+}
+
+void ConsoleGestureCmd::commandTouchStatus(int fd, const std::string &args)
+{
+    std::string logStr;
+    logStr = getTouchesIDInfo();
+    if(!logStr.empty()) {
+        send(fd, logStr.c_str(), logStr.size(), 0);
+    }
+}
+
+void ConsoleGestureCmd::addTouch(float x, float y, int touchID)
+{
+    Touch *touch = new Touch();
+    touch->setTouchInfo(touchID, x, y);
+    touchesMap.emplace(touchID, touch);
+}
+
+cocos2d::Touch *ConsoleGestureCmd::findTouch(int touchID)
+{
+    auto itr = touchesMap.find(touchID);
+    if(itr == touchesMap.end()) return nullptr;
+    return itr->second;
+}
+
+void ConsoleGestureCmd::removeTouch(int touchID)
+{
+    auto itr = touchesMap.find(touchID);
+    if(itr == touchesMap.end()) return;
+
+    touchesMap.erase(itr);
+    Touch *touch = (Touch*)itr->second;
+    touch->release();
+}
+
+std::string ConsoleGestureCmd::getTouchesIDInfo() {
+    std::string logStr;
+    if(touchesMap.empty()) {
+        logStr.append("");
+    } else {
+        logStr.append("\ttouchID\t\tCoordinate\n");
+        for (auto &itr : touchesMap) {
+            std::stringstream ss;
+            int touchID = itr.first;
+            Touch *touch = itr.second;
+            Vec2 pos = Director::getInstance()->convertToGL(touch->getLocationInView());
+            ss << "\t" << touchID << "\t\t" << "(" << pos.x << "," << pos.y << ")" << std::endl;
+            logStr.append(ss.str());
+        }
+    }
+    return logStr;
+}
+
+void ConsoleGestureCmd::commandTap(int fd, const std::string &args)
+{
+    commandTapInternal(fd, args, false);
+}
+
+void ConsoleGestureCmd::commandSwipe(int fd, const std::string &args)
+{
+    commandSwipeInternal(fd, args, false);
+}
+
+void ConsoleGestureCmd::commandPinchIn(int fd, const std::string &args)
+{
+    commandPinchInInternal(fd, args, false);
+}
+
+void ConsoleGestureCmd::commandPinchOut(int fd, const std::string &args)
+{
+    commandPinchOutInternal(fd, args, false);
+}
+
+void ConsoleGestureCmd::commandTapAsync(int fd, const std::string &args)
+{
+    commandTapInternal(fd, args, true);
+}
+
+void ConsoleGestureCmd::commandSwipeAsync(int fd, const std::string &args)
+{
+    commandSwipeInternal(fd, args, true);
+}
+
+void ConsoleGestureCmd::commandPinchInAsync(int fd, const std::string &args)
+{
+    commandPinchInInternal(fd, args, true);
+}
+
+void ConsoleGestureCmd::commandPinchOutAsync(int fd, const std::string &args)
+{
+    commandPinchOutInternal(fd, args, true);
+}

--- a/cocos/base/CCConsoleGestureCmd.h
+++ b/cocos/base/CCConsoleGestureCmd.h
@@ -1,0 +1,87 @@
+/****************************************************************************
+ Copyright (c) 2016      Naruto TAKAHASHI <tnaruto@gmail.com>
+ http://www.cocos2d-x.org
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef CCConsoleGestureCmd_hpp
+#define CCConsoleGestureCmd_hpp
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+#include "base/CCConsole.h"
+#include "base/CCTouch.h"
+
+class ConsoleGestureCmd {
+public:
+    static ConsoleGestureCmd *getInstance() {
+        static ConsoleGestureCmd instance;
+        return &instance;
+    }
+    struct cocos2d::Console::Command& getCommand() { return command; }
+    int getTouchPriority() const { return touchPriority; }
+    void setTouchPriority(int priority) { touchPriority = priority; }
+
+protected:
+    static const int DEFAULT_TOUCH_PRIORITY = -9999;
+
+    ConsoleGestureCmd();
+    ~ConsoleGestureCmd();
+    void addSubCommand(const std::string &name, const std::string &help, std::function<void(int, const std::string&)> callback);
+    void commandGesture(int fd, const std::string &args);
+    void commandHelp(int fd, const std::string &args);
+    void commandTapInternal(int fd, const std::string &args, bool async);
+    void commandSwipeInternal(int fd, const std::string &args, bool async);
+    void commandPinchInInternal(int fd, const std::string &args, bool async);
+    void commandPinchOutInternal(int fd, const std::string &args, bool async);
+    void commandTap(int fd, const std::string &args);
+    void commandSwipe(int fd, const std::string &args);
+    void commandPinchIn(int fd, const std::string &args);
+    void commandPinchOut(int fd, const std::string &args);
+    void commandTapAsync(int fd, const std::string &args);
+    void commandSwipeAsync(int fd, const std::string &args);
+    void commandPinchInAsync(int fd, const std::string &args);
+    void commandPinchOutAsync(int fd, const std::string &args);
+    void commandTouchBegin(int fd, const std::string &args);
+    void commandTouchMove(int fd, const std::string &args);
+    void commandTouchEnd(int fd, const std::string &args);
+    void commandTouchCancel(int fd, const std::string &args);
+    void commandTouchStatus(int fd, const std::string &args);
+
+    std::vector<std::string> &split(const std::string &s, char delim, std::vector<std::string> &elems);
+    std::vector<std::string> split(const std::string &s, char delim);
+
+    void addTouch(float x, float y, int touchID);
+    cocos2d::Touch *findTouch(int touchID);
+    void removeTouch(int touchID);
+    std::string getTouchesIDInfo();
+
+private:
+    struct cocos2d::Console::Command command;
+    std::vector<struct cocos2d::Console::Command> subCommands;
+    int touchPriority;
+    std::unordered_map<int, cocos2d::Touch*> touchesMap;
+
+    CC_DISALLOW_COPY_AND_ASSIGN(ConsoleGestureCmd);
+};
+
+
+#endif /* CCConsoleGestureCmd_hpp */

--- a/cocos/base/CMakeLists.txt
+++ b/cocos/base/CMakeLists.txt
@@ -12,6 +12,7 @@ set(COCOS_BASE_SRC
   base/CCAutoreleasePool.cpp
   base/CCConfiguration.cpp
   base/CCConsole.cpp
+  base/CCConsoleGestureCmd.cpp
   base/CCController.cpp
   base/CCData.cpp
   base/CCDataVisitor.cpp


### PR DESCRIPTION
'gesture' command for CCConsole. uses CCTouchAction.

gesture command has below sub commands.
- tap
- swipe
- pinchIn
- pinchOut
- tapAsync
- swipeAsync
- pinchInAsync
- pinchOutAsync
- touchBegin
- touchMove
- touchEnd
- touchCancel
- touchStatus
# how to enable 'gesture' command

add gesture command  structure  before invoke CCConsole daemon.

```
#include "base/CCConsoleGestureCmd.h"
...
Director::getInstance()->getConsole()->addCommand(ConsoleGestureCmd::getInstance()->getCommand());
Director::getInstance()->listenOnTCP(1234);
```
